### PR TITLE
Modified variable from which DS resources were rendered

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
           readOnly: true
 
         resources:
-          {{ toYaml .Values.daemonset.resources | indent 10 }}
+{{ toYaml .Values.daemonset.resources | indent 10 }}
 
       terminationGracePeriodSeconds: {{ .Values.daemonset.terminationGracePeriodSeconds }}
 

--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
           readOnly: true
 
         resources:
-          {{ toYaml .Values.daemonset.image.resources | indent 10 }}
+          {{ toYaml .Values.daemonset.resources | indent 10 }}
 
       terminationGracePeriodSeconds: {{ .Values.daemonset.terminationGracePeriodSeconds }}
 


### PR DESCRIPTION
## Description

In values.yaml the resources are present under daemonset, where in template of DaemonSet the resources are referred from daemonset.image.resource. 
This mismatch results in DaemonSet getting created with blank resource configuration.

## Motivation and Context

Since the resource were referred from daemonset.image.resource, the deployed daemonset will be created with blank resources, which may affect the scheduling of pds

## How Has This Been Tested?

Generate template using helm template

[render.txt](https://github.com/PaloAltoNetworks/cortex-helm/files/8986045/render.txt)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
