### PR TITLE
chart: change deploymentSecret creation to true

### DIFF
--- a/charts/cortex-agent/values.yaml
+++ b/charts/cortex-agent/values.yaml
@@ -12,7 +12,7 @@ dockerPullSecret:
 
 deploymentSecret:
   # Set to "false" to inject distributionId externally, e.g. Vault-agent-injector
-  create: false
+  create: true
 
 serviceAccount:
   # create/don't create service account


### PR DESCRIPTION
We want deploymentSecret to be created by default

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
