### PR TITLE
chart: support for bottlerocketos and container_scan_mode (pcc)

### DIFF
--- a/charts/cortex-agent/Chart.yaml
+++ b/charts/cortex-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Cortex XDR agent helm chart
 
 type: application
 
-version: 1.3.0
+version: 1.4.0
 
 appVersion: 1.0.0
 

--- a/charts/cortex-agent/README.md
+++ b/charts/cortex-agent/README.md
@@ -8,7 +8,7 @@
 | 1.1.0         | >=7.5         |
 | 1.2.0         | >=7.5         |
 | 1.3.0         | >=7.5         |
-| 1.4.0         | >=7.5         | Support for endpointTags from agent 8.1
+| 1.4.0         | >=7.5         | Support for endpointTags and containerScanMode from agent 8.1
 
 ## Installing Cortex XDR helm chart
 
@@ -92,7 +92,9 @@ Even when using `--reuse-values` (which uses the values of the previous installa
 | `agent.proxyList`                      | List of proxies that the agent will use (e.g `--set agent.proxyList="10.0.0.1:8000\,10.0.0.2:9000"`)       |
 | `agent.endpointTags`                   | List of tags describing the endpoint (e.g `--set agent.endpointTags="main\,dev-machine1\,test\ 123"`)      | Since 1.4.0
 | `agent.nodeSelector`                   | Node selector (e.g `--set daemonset.nodeSelector.<key=value>`, each key+value will need their own `--set`) |
-| `serviceAccount.openshift.scc.create`  | Enable `SecurityConstraintsContext` for openshift platform (Required when installing on openshift          |
+| `agent.containerScanMode.enable`       | Enable the container scan mode (for pcc)                                                                   | Since 1.4.0
+| `serviceAccount.openshift.scc.create`  | Enable `SecurityConstraintsContext` for openshift platform (Required when installing on openshift)         |
+| `bottlerocketos.create`                | Support for BottlerocketOS platform (Required when installing on BottlerocketOS)                           |
 
 Note: Helm requires commas in arguments to be escaped.
 

--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -51,6 +51,10 @@ spec:
         imagePullPolicy: {{ .Values.daemonset.image.pullPolicy }}
 
         securityContext:
+          {{- if .Values.bottlerocketos.create }}
+          seLinuxOptions:
+            type: super_t
+          {{- end }}
           capabilities:
             add:
             - SYS_ADMIN
@@ -80,6 +84,10 @@ spec:
           value: {{ .Values.agent.proxyList | quote }}
         - name: XDR_ENDPOINT_TAGS
           value: {{ .Values.agent.endpointTags | quote }}
+        {{- if .Values.agent.containerScanMode.enable }}
+        - name: XDR_ENABLE_CONTAINER_SCAN_MODE
+          value: "{{- .Values.agent.containerScanMode.enable }}"
+        {{- end }}
 
         volumeMounts:
 
@@ -119,8 +127,13 @@ spec:
 
       - name: var-log
         hostPath:
+            {{- if .Values.bottlerocketos.create }}
+            path: /local/traps/var/log
+            type: DirectoryOrCreate
+            {{- else }}
             path: /var/log
             type: Directory
+            {{- end }}
 
       - name: host-km-directory
         hostPath:
@@ -145,7 +158,11 @@ spec:
 
       - name: agent-ids
         hostPath:
+          {{- if .Values.bottlerocketos.create }}  
+          path: /local/traps/etc/traps
+          {{- else }}
           path: /etc/traps
+          {{- end }}
           type: DirectoryOrCreate
 
       {{- if .Values.deploymentSecret.create }}

--- a/charts/cortex-agent/values.yaml
+++ b/charts/cortex-agent/values.yaml
@@ -27,6 +27,10 @@ serviceAccount:
     scc:
       create: false
 
+bottlerocketos:
+  # Deploy on BotllerocketOS platform
+  create: false
+
 rbac:
   # create/don't create Cluster Role and Cluster Role Bindings
   create: true
@@ -44,6 +48,10 @@ agent:
 
   # Tags describing the endpoint, for example: "main,dev-machine1,test 123"
   endpointTags: ""
+
+  # Enable an internal mode with a reduced feature set
+  containerScanMode:
+    enable: false
 
 daemonset:
   # node labels to match pods with


### PR DESCRIPTION
Add the option to create helm chart for BottlerocketOS platofrm
Add the option to create helm chart with Container Scan Mode (for PCC)
Bump helm chart version to 1.4.0