### PR TITLE
charts: PSS pod secuiry to all deploymnets

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -3,9 +3,9 @@ kind: DaemonSet
 metadata:
   name: {{ include "cortex-xdr.fullname" . }}
   labels: {{- include "cortex-xdr.labels" . | nindent 4 }}
-  {{- if .Values.platform.talos }}
     pod-security.kubernetes.io/enforce: privileged
-  {{- end }}
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
 
 spec:
   selector:


### PR DESCRIPTION
Enable Pod Security Standard (PSS) as privilege for all enforce/audit/warn profiles.
