### PR TITLE
Update daemonset.yaml

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -172,7 +172,7 @@ spec:
           secretName: {{ include "cortex-xdr.deploymentSecretName" . }}
       {{- end }}
 
-      {{- if .Values.dockerPullSecret.create -}}
+      {{- if .Values.dockerPullSecret.create }}
       imagePullSecrets:
       - name: {{ include "cortex-xdr.dockerPullSecretName" . }}
       {{- end }}


### PR DESCRIPTION
Fix helm chart when using pullsecret.

## Description
We're trying to deploy this out to several clusters today.  Please merge and re-build the chart.

## Motivation and Context

If you use the imagepullsecret this fixes template language that would cause the imagePullSecret to end up at the end of the previous line of text regardless of the # of line breaks you have in the template.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
helm template cortex-xdr . //with all the goodies

<!--- Include details of your testing environment, and the tests you ran to -->
macbook

<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate)
![Uploading image.png…]()

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
