### PR TITLE
chart: fix pull secret rendering

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -172,7 +172,7 @@ spec:
           secretName: {{ include "cortex-xdr.deploymentSecretName" . }}
       {{- end }}
 
-      {{- if .Values.dockerPullSecret.create }}
+      {{- if (include "cortex-xdr.dockerPullSecretName" .) }}
       imagePullSecrets:
       - name: {{ include "cortex-xdr.dockerPullSecretName" . }}
       {{- end }}


### PR DESCRIPTION
we don't want to render `dockerPullSecrets` tag in our daemonset yaml when `dockerPullSecret.create` and `dockerPullSecrets.name` are unset. Therefore we should check if the name of the final docker pull secret to use is not empty.

## Description

Fix bug when docker pull secret is untouched by the user

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
