### PR TITLE
chart: fix scc to match daemonset

### DIFF
--- a/charts/cortex-agent/templates/openshift-scc.yaml
+++ b/charts/cortex-agent/templates/openshift-scc.yaml
@@ -11,6 +11,7 @@ allowHostPID: true
 allowHostPorts: true
 allowedCapabilities:
   - SYS_ADMIN
+  - SYSLOG
   - SYS_CHROOT
   - SYS_MODULE
   - SYS_PTRACE
@@ -40,7 +41,7 @@ users:
   - system:serviceaccount:{{ .Values.namespace.name }}
   - system:serviceaccount:{{ .Values.namespace.name }}:{{ include "cortex-xdr.serviceAccountName" . }}
 volumes:
+  - downwardAPI
   - hostPath
   - secret
-  - downwardAPI
 {{- end }}


### PR DESCRIPTION
## Motivation and Context
- the SCC for OpenShift does not match the capabilities of the DaemonSet
- the volumes in the SCC should be listed in alphabetical order, otherwise this cause issues if the Helm chart is installed using ArgoCD

## How Has This Been Tested?
The updated SCC was manually tested on a OCP cluster with version 4.12.39.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
