### PR TITLE
chart: fix openshift scc to match daemonset

### DIFF
--- a/charts/cortex-agent/templates/openshift-scc.yaml
+++ b/charts/cortex-agent/templates/openshift-scc.yaml
@@ -11,6 +11,7 @@ allowHostPID: true
 allowHostPorts: true
 allowedCapabilities:
   - SYS_ADMIN
+  - SYSLOG
   - SYS_CHROOT
   - SYS_MODULE
   - SYS_PTRACE
@@ -40,7 +41,7 @@ users:
   - system:serviceaccount:{{ .Values.namespace.name }}
   - system:serviceaccount:{{ .Values.namespace.name }}:{{ include "cortex-xdr.serviceAccountName" . }}
 volumes:
+  - downwardAPI
   - hostPath
   - secret
-  - downwardAPI
 {{- end }}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

- the SCC for OpenShift does not match the capabilities of the DaemonSet
- the volumes in the SCC should be listed in alphabetical order, otherwise this cause issues if the Helm chart is installed using ArgoCD

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
