### PR TITLE
helm: Disable AppArmor enforcement in K8s version 1.30+

### DIFF
--- a/charts/cortex-agent/README.md
+++ b/charts/cortex-agent/README.md
@@ -14,6 +14,7 @@
 | 1.6.1         | >=7.5         | Namespace is created by the chart and no longer by helm itself. Therefore the helm namespace will be `default` (unless chosen otherwise).
 | 1.6.2         | >=7.5         |
 | 1.7.0         | >=7.5         | Bottlerocket support
+| 1.8.0         | >=7.5         | SELinux spc_t (Super Privileged Container) support
 
 ## Installing Cortex XDR helm chart
 
@@ -99,6 +100,7 @@ Even when using `--reuse-values` (which uses the values of the previous installa
 | `agent.clusterName`                    | Name of the kuberenets cluster, will be used as part of the information sent to the server                 | Since 1.5.0, agent >= 8.2
 | `namespace.name`                       | Name of the namespace the agent resides on                                                                 | Since 1.6.0
 | `namespace.create`                     | Create/Don't create namespace for the agent                                                                | Since 1.6.0
+| `daemonset.selinuxOptionsSpcT`         | Set SELinux Options type to 'spc_t'                                                                        | Since 1.8.0
 
 Note: Helm requires commas in arguments to be escaped.
 

--- a/charts/cortex-agent/templates/_helpers.tpl
+++ b/charts/cortex-agent/templates/_helpers.tpl
@@ -94,3 +94,16 @@ Create the path of the /var/log volume mount on the host fs
 /var/log
 {{- end }}
 {{- end }}
+
+{{/*
+Specify the SELinux context options type
+*/}}
+{{- define "cortex-xdr.xdrSelinuxOptionsType" -}}
+{{- if .Values.platform.bottlerocket -}}
+{{- print "super_t" -}}
+{{- else if .Values.daemonset.selinuxOptionsSpcT -}}
+{{- print "spc_t" -}}
+{{- else -}}
+{{- print "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -51,10 +51,11 @@ spec:
         imagePullPolicy: {{ .Values.daemonset.image.pullPolicy }}
 
         securityContext:
-          {{- if .Values.platform.bottlerocket }}
+          {{- $selinuxType := include "cortex-xdr.xdrSelinuxOptionsType" . | trim }}
+          {{- if ne $selinuxType "" }}
           seLinuxOptions:
-            type: super_t
-          {{- end }}
+            type: {{ $selinuxType | quote }}
+          {{ end }}
           capabilities:
             add:
             - SYS_ADMIN

--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -15,8 +15,10 @@ spec:
     metadata:
       labels: {{- include "cortex-xdr.labels" . | nindent 8 }}
 
+      {{- if semverCompare "<1.30-0" .Capabilities.KubeVersion.Version }}
       annotations:
-{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+        {{ toYaml .Values.daemonset.podAnnotations }}
+      {{- end }}
 
     spec:
       {{- if .Values.serviceAccount.create }}
@@ -55,7 +57,15 @@ spec:
           {{- if ne $selinuxType "" }}
           seLinuxOptions:
             type: {{ $selinuxType | quote }}
-          {{ end }}
+          {{- end }}
+          {{- /*
+          Prior to Kubernetes v1.30, AppArmor was specified through annotations.
+          https://kubernetes.io/docs/tutorials/security/apparmor/#specifying-apparmor-confinement
+          */ -}}
+          {{- if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }}
+          appArmorProfile:
+            type: Unconfined
+          {{- end }}
           capabilities:
             add:
             - SYS_ADMIN

--- a/charts/cortex-agent/values.yaml
+++ b/charts/cortex-agent/values.yaml
@@ -101,6 +101,7 @@ daemonset:
     requests:
       cpu: "200m"
       memory: "600Mi"
+  selinuxOptionsSpcT: false
 
 namespace:
   create: true


### PR DESCRIPTION
This commit introduces support for disabling AppArmor enforcement on the
agent pod in K8s versions above 1.30. The current AppArmor property
(under the Annotations property) is set to be deprecated in future versions,
so based version logic was added do include the correct property