### PR TITLE
helm: Disable AppArmor enforcement in K8s version 1.30+

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -15,8 +15,10 @@ spec:
     metadata:
       labels: {{- include "cortex-xdr.labels" . | nindent 8 }}
 
+      {{- if semverCompare "<1.30-0" .Capabilities.KubeVersion.Version }}
       annotations:
-{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+        {{ toYaml .Values.daemonset.podAnnotations }}
+      {{- end }}
 
     spec:
       {{- if .Values.serviceAccount.create }}
@@ -55,7 +57,15 @@ spec:
           {{- if ne $selinuxType "" }}
           seLinuxOptions:
             type: {{ $selinuxType | quote }}
-          {{ end }}
+          {{- end }}
+          {{- /*
+          Prior to Kubernetes v1.30, AppArmor was specified through annotations.
+          https://kubernetes.io/docs/tutorials/security/apparmor/#specifying-apparmor-confinement
+          */ -}}
+          {{- if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }}
+          appArmorProfile:
+            type: Unconfined
+          {{- end }}
           capabilities:
             add:
             - SYS_ADMIN


### PR DESCRIPTION
This commit introduces support for disabling AppArmor enforcement on the agent pod in K8s versions above 1.30. The current AppArmor property (under the Annotations property) is set to be deprecated in future versions, so based version logic was added do include the correct property.