### PR TITLE
feat: include the option so deployment secret can be created by external source

### DIFF
--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -143,7 +143,7 @@ spec:
           mountPath: /etc/traps
         {{- end }}
 
-        {{- if .Values.deploymentSecret.create }}
+        {{- if or .Values.deploymentSecret.create .Values.deploymentSecret.name }}
         - name: deployment-secrets
           mountPath: /opt/traps/config/deployment
           readOnly: true
@@ -205,10 +205,10 @@ spec:
           type: DirectoryOrCreate
       {{- end }}
 
-      {{- if .Values.deploymentSecret.create }}
+      {{- if or .Values.deploymentSecret.create .Values.deploymentSecret.name }}
       - name: deployment-secrets
         secret:
-          secretName: {{ include "cortex-xdr.deploymentSecretName" . }}
+          secretName: {{ .Values.deploymentSecret.name | default (include "cortex-xdr.deploymentSecretName" .) }}
       {{- end }}
 
       {{- if (include "cortex-xdr.dockerPullSecretName" .) }}

--- a/charts/cortex-agent/templates/deployment-secret.yaml
+++ b/charts/cortex-agent/templates/deployment-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cortex-xdr.deploymentSecretName" . }}
+  name: {{ .Values.deploymentSecret.name | default (include "cortex-xdr.deploymentSecretName" .) }}
   namespace: {{ .Values.namespace.name }}
 type: Opaque
 stringData:

--- a/charts/cortex-agent/values.yaml
+++ b/charts/cortex-agent/values.yaml
@@ -14,6 +14,9 @@ deploymentSecret:
   # Set to "false" to inject distributionId externally, e.g. Vault-agent-injector
   create: true
 
+  # In case you want to create your own deployment secret, enter its name here
+  name: ""
+
 serviceAccount:
   # create/don't create service account
   create: true


### PR DESCRIPTION


## Description

This change, allows the secret deployment-secret to be created by external source, for example External Secrets Operator.

## Motivation and Context

External Secrets Operator is a CNCF supported solution which is widely used by customers, but the current deployment don't support the creation of the secret related to the distribution Id by an external source, as is required by the external secrets operator and other tools of secrets management. 

## How Has This Been Tested?

This has been tested by using the following:
- Google Secrets Manager: The storage where the distribution Id and the docker pull secret is located. The secret hold the following format:
```json
{
    "DISTRIBUTION_ID": "bbcd....",
    "DOCKER_PULL_SECRET": "eyJhd..."
}
```
- Cluster: RKE cluster
- External Secrets Operator: This tool was [installed](https://external-secrets.io/v2.4.1/introduction/getting-started/) in the cluster and the following resources were created:
  - Namespace: cortex-xdr
  - Secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: gcp-sa-secret
  namespace: cortex-xdr
type: Opaque
stringData:
  secret-access-credentials: |-
    {
      "type": "service_account",
      "project_id": "external-secrets-operator",
      "private_key_id": "",
      "private_key": "-----BEGIN PRIVATE KEY-----\nA key\n-----END PRIVATE KEY-----\n",
      "client_email": "test-service-account@external-secrets-operator.iam.gserviceaccount.com",
      "client_id": "client ID",
      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
      "token_uri": "https://oauth2.googleapis.com/token",
      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service-account%40external-secrets-operator.iam.gserviceaccount.com"
    }
```
  - SecretStore:
```yaml
apiVersion: external-secrets.io/v1
kind: SecretStore
metadata:
  name: demo-store
  namespace: cortex-xdr
spec:
  provider:
    gcpsm:
      auth:
        secretRef:
          secretAccessKeySecretRef:
            name: gcp-sa-secret
            key: secret-access-credentials
      projectID: my-project
```
  - ExternalSecrets: Deployment Secret & Docker Pull Secret
   
```yaml
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: distribution-id
  namespace: cortex-xdr
spec:
  refreshInterval: 1h0m0s
  secretStoreRef:
    name: demo-store
    kind: SecretStore
  target:
    name: distribution-id
    creationPolicy: Owner
  data:
  - secretKey: distribution-id
    remoteRef:
      key: cortex-xdr
      property: DISTRIBUTION_ID
      conversionStrategy: Default
      decodingStrategy: None
      metadataPolicy: None
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: docker-pull-secret
  namespace: cortex-xdr
spec:
  refreshInterval: 1h0m0s
  secretStoreRef:
    name: demo-store
    kind: SecretStore
  target:
    name: docker-pull-secret
    creationPolicy: Owner
    template:
      type: kubernetes.io/dockerconfigjson
  data:
  - secretKey: .dockerconfigjson
    remoteRef:
      key: cortex-xdr
      property: DOCKER_PULL_SECRET
      conversionStrategy: Default
      decodingStrategy: Base64
      metadataPolicy: None
```
Once the resources were created. I've executed the following command:

```bash
helm upgrade --install cortex-xdr cortex-xdr-1.8.0.tgz \
--set namespace.name=cortex-xdr \
--set namespace.create=false \
--set daemonset.image.repository=us-central1-docker.pkg.dev/xdr-us-1234567890123/agent-docker/cortex-agent \
--set daemonset.image.tag=9.2.0.86 \
--set dockerPullSecret.create=false \
--set dockerPullSecret.name=docker-pull-secret \
--set deploymentSecret.create=false \
--set deploymentSecret.name=distribution-id \
--set agent.clusterName=testing
```

I've also tested using the command that delivers Cortex Cloud which give satisfactory results also.

## Screenshots (if appropriate)

- Helm installation succeded
<img width="893" height="439" alt="image" src="https://github.com/user-attachments/assets/5ede84f4-b6a5-4ccc-95d9-474baebf9ca8" />

- Connectivity test working
<img width="844" height="464" alt="image" src="https://github.com/user-attachments/assets/d087512b-f585-4685-a1cc-a83c89fb01e1" />

- View from the web interface
<img width="1309" height="210" alt="image" src="https://github.com/user-attachments/assets/0c08b2ea-02f9-4a7c-ac97-12968d5efdad" />


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
