### PR TITLE
feat: split daemonset resources into full/sensor profiles selected by…

### DIFF
--- a/charts/cortex-agent/Chart.yaml
+++ b/charts/cortex-agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Cortex XDR agent helm chart
 
 type: application
 
-version: 1.9.0
+version: 1.10.0
 
 appVersion: 1.0.0
 

--- a/charts/cortex-agent/README.md
+++ b/charts/cortex-agent/README.md
@@ -16,6 +16,7 @@
 | 1.7.0         | >=7.5         | Bottlerocket support
 | 1.8.0         | >=7.5         | SELinux spc_t (Super Privileged Container) support
 | 1.9.0         | >=7.5         | Support external deployment secret
+| 1.10.0        | >=7.5         | `daemonset.resources` split into `full`/`sensor` profiles, automatically selected by `agent.sensorMode`
 
 ## Installing Cortex XDR helm chart
 
@@ -103,9 +104,37 @@ Even when using `--reuse-values` (which uses the values of the previous installa
 | `namespace.name`                       | Name of the namespace the agent resides on                                                                 | Since 1.6.0
 | `namespace.create`                     | Create/Don't create namespace for the agent                                                                | Since 1.6.0
 | `daemonset.selinuxOptionsSpcT`         | Set SELinux Options type to 'spc_t'                                                                        | Since 1.8.0
-| `agent.sensorMode`                     | Enable sensor mode for lightweight cloud-native deployments                                                | agent >= 9.3
+| `agent.sensorMode`                     | Enable sensor mode for lightweight cloud-native deployments. Also selects `daemonset.resources.sensor` over `daemonset.resources.full` | Since 1.10.0, agent >= 9.3
+| `daemonset.resources.full`             | Resource requests/limits used when `agent.sensorMode` is `false` (default)                                 | Since 1.10.0
+| `daemonset.resources.sensor`           | Resource requests/limits used when `agent.sensorMode` is `true`                                            | Since 1.10.0
 
 Note: Helm requires commas in arguments to be escaped.
+
+### Migration from chart < 1.10.0
+
+In 1.10.0 the `daemonset.resources` block was restructured. The previous shape:
+
+```yaml
+daemonset:
+  resources:
+    limits:    { memory: "2Gi", ephemeral-storage: "10Gi" }
+    requests:  { cpu: "200m", memory: "600Mi", ephemeral-storage: "5Gi" }
+```
+
+is now nested under a profile name:
+
+```yaml
+daemonset:
+  resources:
+    full:    # used when agent.sensorMode == false
+      limits:    { memory: "2Gi", ephemeral-storage: "10Gi" }
+      requests:  { cpu: "200m", memory: "600Mi", ephemeral-storage: "5Gi" }
+    sensor:  # used when agent.sensorMode == true
+      limits:    { cpu: "1000m", memory: "350Mi", ephemeral-storage: "10Gi" }
+      requests:  { cpu: "200m",  memory: "256Mi", ephemeral-storage: "5Gi" }
+```
+
+If you previously overrode `daemonset.resources.limits.*` or `daemonset.resources.requests.*`, you must move those overrides under `daemonset.resources.full.*` (and/or `daemonset.resources.sensor.*`) when upgrading. Overrides left at the old paths will be silently ignored.
 
 ## Uninstalling Cortex XDR helm chart
 

--- a/charts/cortex-agent/templates/_helpers.tpl
+++ b/charts/cortex-agent/templates/_helpers.tpl
@@ -107,3 +107,16 @@ Specify the SELinux context options type
 {{- print "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Select the daemonset resources block based on agent.sensorMode.
+  sensorMode: false -> .Values.daemonset.resources.full
+  sensorMode: true  -> .Values.daemonset.resources.sensor
+*/}}
+{{- define "cortex-xdr.daemonsetResources" -}}
+{{- if .Values.agent.sensorMode -}}
+{{- toYaml .Values.daemonset.resources.sensor -}}
+{{- else -}}
+{{- toYaml .Values.daemonset.resources.full -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cortex-agent/templates/daemonset.yaml
+++ b/charts/cortex-agent/templates/daemonset.yaml
@@ -150,7 +150,7 @@ spec:
         {{- end }}
 
         resources:
-{{ toYaml .Values.daemonset.resources | indent 10 }}
+          {{- include "cortex-xdr.daemonsetResources" . | nindent 10 }}
 
       terminationGracePeriodSeconds: {{ .Values.daemonset.terminationGracePeriodSeconds }}
 

--- a/charts/cortex-agent/values.yaml
+++ b/charts/cortex-agent/values.yaml
@@ -103,16 +103,30 @@ daemonset:
     # for autopilot
     url: ""
 
+  # Resource profiles for the cortex agent container.
+  # The profile used at runtime is selected by `agent.sensorMode`:
+  #   sensorMode: false -> resources.full   (default, full agent)
+  #   sensorMode: true  -> resources.sensor (lightweight cloud-native)
   # These values are the recommended values for cortex agent
   # and are not recommended to change!
   resources:
-    limits:
-      memory: "2Gi"
-      ephemeral-storage: "10Gi"
-    requests:
-      cpu: "200m"
-      memory: "600Mi"
-      ephemeral-storage: "5Gi"
+    full:
+      limits:
+        memory: "2Gi"
+        ephemeral-storage: "10Gi"
+      requests:
+        cpu: "200m"
+        memory: "600Mi"
+        ephemeral-storage: "5Gi"
+    sensor:
+      limits:
+        cpu: "1000m"
+        memory: "350Mi"
+        ephemeral-storage: "10Gi"
+      requests:
+        cpu: "200m"
+        memory: "256Mi"
+        ephemeral-storage: "5Gi"
   selinuxOptionsSpcT: false
 
 namespace:


### PR DESCRIPTION
… agent.sensorMode

When agent.sensorMode is true, the agent runs as a lightweight cloud-native sensor and needs a different resource footprint than the full agent.

Changes:
- values.yaml: daemonset.resources is now a map with two named profiles, 'full' (default) and 'sensor', each with their own limits/requests.
- _helpers.tpl: add cortex-xdr.daemonsetResources helper that picks the correct profile based on .Values.agent.sensorMode.
- daemonset.yaml: use the new helper instead of a hard-coded toYaml call.
- Chart.yaml: bump chart version 1.9.0 -> 1.10.0.
- README.md: document the new resources.full / resources.sensor keys and add a migration note for users with existing resources.* overrides.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
